### PR TITLE
- Add Test Devices on Banner Renderer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,7 @@ Thumbs.db
 
 #dotCover
 *.dotCover
+/.vs/VSWorkspaceState.json
+/.vs/slnx.sqlite
+/.vs/ProjectSettings.json
+/PlugIn/UpgradeLog.htm

--- a/PlugIn/Xamarinos.AdMob.Forms/Xamarinos.AdMob.Forms.FormsPlugin.Abstractions/Xamarinos.AdMob.Forms.Abstractions.csproj
+++ b/PlugIn/Xamarinos.AdMob.Forms/Xamarinos.AdMob.Forms.FormsPlugin.Abstractions/Xamarinos.AdMob.Forms.Abstractions.csproj
@@ -13,7 +13,7 @@
     <DefaultLanguage>en-US</DefaultLanguage>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworkProfile>Profile78</TargetFrameworkProfile>
+    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/PlugIn/Xamarinos.AdMob.Forms/Xamarinos.AdMob.Forms.FormsPlugin.Android/AdBannerRenderer.cs
+++ b/PlugIn/Xamarinos.AdMob.Forms/Xamarinos.AdMob.Forms.FormsPlugin.Android/AdBannerRenderer.cs
@@ -4,18 +4,22 @@ using Xamarin.Forms;
 using Xamarinos.AdMob.Forms.Android;
 using Xamarin.Forms.Platform.Android;
 using Android.Gms.Ads;
+using System.Collections.Generic;
 
 [assembly: ExportRenderer(typeof(Xamarinos.AdMob.Forms.AdBanner), typeof(Xamarinos.AdMob.Forms.Android.AdBannerRenderer))]
 namespace Xamarinos.AdMob.Forms.Android
 {
     public class AdBannerRenderer : ViewRenderer
     {
+        static string[] _TestDevices = new string[] { };
+
         public AdBannerRenderer()
         {
         }
 
-        public static void Init()
+        public static void Init(params string[] testDevices)
         {
+            _TestDevices = testDevices;
             var debug = true;
         }
 
@@ -28,7 +32,15 @@ namespace Xamarinos.AdMob.Forms.Android
                 var adview = new AdView(Context);
                 adview.AdSize = AdSize.Banner;
                 adview.AdUnitId = adsbanner.AdID;
-                var requestbuilder = new AdRequest.Builder();
+                var requestbuilder = new AdRequest.Builder().AddTestDevice(AdRequest.DeviceIdEmulator);
+                if (_TestDevices?.Length >0)
+                {
+                    foreach(string thisTestDevice in _TestDevices)
+                    {
+                        requestbuilder.AddTestDevice(thisTestDevice);
+                    }
+                }
+                
                 adview.LoadAd(requestbuilder.Build());
                 base.SetNativeControl(adview);
             }

--- a/PlugIn/Xamarinos.AdMob.Forms/Xamarinos.AdMob.Forms.FormsPlugin.Android/Xamarinos.AdMob.Forms.Android.csproj
+++ b/PlugIn/Xamarinos.AdMob.Forms/Xamarinos.AdMob.Forms.FormsPlugin.Android/Xamarinos.AdMob.Forms.Android.csproj
@@ -18,7 +18,7 @@
     <DevInstrumentationEnabled>True</DevInstrumentationEnabled>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
-    <TargetFrameworkVersion>v6.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v7.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
I added a parameter to the AdBannerRenderer on android.
The interstitial had the test devices option, but the Banner didn't.
This commit adds this option.